### PR TITLE
fix documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
-#![feature(external_doc)]
 #![deny(missing_docs)]
-#![doc(include = "../readme.md")]
+#![doc = include_str!("../readme.md")]
 
 use std::fmt;
 


### PR DESCRIPTION
remove `external_doc` which is deprecated, replaced with `doc = include_str!("filename")`